### PR TITLE
암살 로직 업데이트

### DIFF
--- a/Paran/Assets/Scripting/AssasinManager.cs
+++ b/Paran/Assets/Scripting/AssasinManager.cs
@@ -1,58 +1,68 @@
 using UnityEngine;
 using System.Collections.Generic;
+using NUnit.Framework.Constraints;
 
-public class AssasinManager : MonoBehaviour
+public class PlayerInteract : MonoBehaviour
 {
-    private List<GameObject> enemiesInRange = new List<GameObject>();
 
     [SerializeField] private Transform playerTransform;
-    [SerializeField] private float alignDistance = 1.5f; // 암살 애니메이션 정렬 거리
+    [SerializeField] private float alignDistance = 0.5f; // 암살 애니메이션 정렬 거리
     [SerializeField] private Vector3 positionOffset = Vector3.zero;
 
     void Update()
     {
         if (Input.GetMouseButtonDown(0))
         {
-            if (enemiesInRange.Count == 1)
+            Interaction();
+        }
+    }
+
+    void Interaction()
+    {
+        Vector3 sphereCenter = transform.position + transform.forward * alignDistance;
+        Collider[] hits = Physics.OverlapSphere(sphereCenter, alignDistance);
+
+        foreach (var hit in hits)
+        {
+            if (hit.CompareTag("Enemy"))
             {
-                GameObject enemy = enemiesInRange[0];
+                Debug.Log("1단계 통과");
+                EnemySearch stateHandler = hit.GetComponent<EnemySearch>();
+                if (stateHandler == null) return;
 
-                // 거리 정렬 및 위치 맞춤
-                Vector3 directionToEnemy = (enemy.transform.position - playerTransform.position).normalized;
-                playerTransform.position = enemy.transform.position - directionToEnemy * alignDistance + positionOffset;
-                playerTransform.LookAt(enemy.transform); // 정렬
+                // 후면 체크
+                Vector3 toEnemy = (hit.transform.position - transform.position).normalized;
+                float dot = Vector3.Dot(hit.transform.forward, toEnemy);
 
-                // 상태 변경
-                EnemySearch stateHandler = enemy.GetComponent<EnemySearch>();
-                if (stateHandler != null)
+                Debug.Log("Dot value: " + dot);
+                Debug.Log("Enemy State: " + stateHandler.GetState());
+
+                if (dot > 0.7f && stateHandler.GetState() != EnemySearch.EnemyState.Search)
                 {
+                    Debug.Log("2단계 통과");
+                    Vector3 directionToEnemy = (hit.transform.position - transform.position).normalized;
+                    Vector3 newPosition = hit.transform.position - directionToEnemy * alignDistance + positionOffset;
+                    newPosition.y = playerTransform.position.y; // Y값 고정
+                    playerTransform.position = newPosition;
+
+                    Vector3 lookDirection = new Vector3(hit.transform.position.x, playerTransform.position.y, hit.transform.position.z);
+                    playerTransform.LookAt(lookDirection);
+
+                    //애니메이션 여기 추가
                     stateHandler.SetState(EnemySearch.EnemyState.Died);
-                }
-                else
-                {
-                    Debug.LogWarning("EnemySearch 스크립트가 없습니다.");
+                    break; // 하나만 암살
                 }
             }
-            else if (enemiesInRange.Count > 1)
+            else if (hit.CompareTag("InteractableObject"))
             {
-                Debug.LogError("암살 대상이 둘 이상입니다!");
+
             }
         }
     }
-
-    private void OnTriggerEnter(Collider other)
+    void OnDrawGizmosSelected()
     {
-        if (other.CompareTag("Enemy") && !enemiesInRange.Contains(other.gameObject))
-        {
-            enemiesInRange.Add(other.gameObject);
-        }
-    }
-
-    private void OnTriggerExit(Collider other)
-    {
-        if (other.CompareTag("Enemy") && enemiesInRange.Contains(other.gameObject))
-        {
-            enemiesInRange.Remove(other.gameObject);
-        }
+        Gizmos.color = Color.red;
+        Vector3 sphereCenter = transform.position + transform.forward * alignDistance;
+        Gizmos.DrawWireSphere(sphereCenter, alignDistance);
     }
 }

--- a/Paran/Assets/Scripting/PlayerMove.cs
+++ b/Paran/Assets/Scripting/PlayerMove.cs
@@ -125,10 +125,12 @@ public class PlayerMove : MonoBehaviour
             cc.Move(moveDir * moveSpeed * Time.deltaTime);
         }
         animator.SetFloat("Speed", new Vector3(x,0,z).magnitude);
-        RaycastHit hit;
-        if (!Physics.Raycast(transform.position, -transform.up, out hit, 1))
-            velocity.y += gravity * Time.deltaTime;
-        else velocity.y = 0;
+
+        bool isGrounded = cc.isGrounded;
+        
+        if (isGrounded && velocity.y < 0) velocity.y = 0;
+
+        velocity.y += gravity * Time.deltaTime;
         cc.Move(velocity * Time.deltaTime);
     }
 }

--- a/Paran/Assets/TestScene.unity
+++ b/Paran/Assets/TestScene.unity
@@ -386,37 +386,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &615136357
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 615136358}
-  m_Layer: 3
-  m_Name: Ground Check
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &615136358
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 615136357}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.95, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 744466555}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &630305164 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 5866666021909216657, guid: 0796ce0366bff414d870e6ac89dbbaee, type: 3}
@@ -799,7 +768,6 @@ GameObject:
   - component: {fileID: 744466557}
   - component: {fileID: 744466556}
   - component: {fileID: 744466558}
-  - component: {fileID: 744466559}
   - component: {fileID: 744466560}
   m_Layer: 3
   m_Name: Player
@@ -817,11 +785,10 @@ Transform:
   m_GameObject: {fileID: 744466554}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 148.5, y: -5.314, z: 26.49}
+  m_LocalPosition: {x: 148.5, y: -5.223, z: 26.49}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 615136358}
   - {fileID: 417646365}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -837,7 +804,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b4f0317884156054c921aff705682d58, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  standSpeed: 5
+  walkSpeed: 7
   crawlSpeed: 3
   runSpeed: 10
   gravity: -9.8
@@ -845,6 +812,7 @@ MonoBehaviour:
   animator: {fileID: 630305164}
   currentState: 0
   moveSpeed: 5
+  targetSpeed: 0
 --- !u!143 &744466557
 CharacterController:
   m_ObjectHideFlags: 0
@@ -867,7 +835,7 @@ CharacterController:
   m_Radius: 0.35
   m_SlopeLimit: 45
   m_StepOffset: 0.3
-  m_SkinWidth: 0.08
+  m_SkinWidth: 0.0001
   m_MinMoveDistance: 0.001
   m_Center: {x: 0, y: 0.9, z: 0}
 --- !u!136 &744466558
@@ -893,27 +861,6 @@ CapsuleCollider:
   m_Height: 1.8
   m_Direction: 1
   m_Center: {x: 0, y: 0.9, z: 0}
---- !u!135 &744466559
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 744466554}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 1
-  m_Center: {x: 0, y: 0.9, z: 1}
 --- !u!114 &744466560
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -927,7 +874,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerTransform: {fileID: 744466555}
-  alignDistance: 1
+  alignDistance: 0.5
   positionOffset: {x: 0, y: 0, z: 0}
 --- !u!1001 &862786303
 PrefabInstance:
@@ -1546,37 +1493,6 @@ MonoBehaviour:
   m_ObsoleteUseShadowQualitySettings: 0
   m_ObsoleteCustomShadowResolution: 512
   m_ObsoleteContactShadows: 0
---- !u!1 &1810978915
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1810978916}
-  m_Layer: 0
-  m_Name: Ground Check
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1810978916
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1810978915}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.95, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1976438685}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1825213176
 GameObject:
   m_ObjectHideFlags: 0
@@ -1851,13 +1767,13 @@ CharacterController:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Height: 5.5
-  m_Radius: 0.7
+  m_Height: 2
+  m_Radius: 0.35
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 3.5, z: 0}
+  m_Center: {x: 0, y: 1.6, z: 0}
 --- !u!4 &1976438685
 Transform:
   m_ObjectHideFlags: 0
@@ -1867,11 +1783,10 @@ Transform:
   m_GameObject: {fileID: 1976438681}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: 0.7375079, z: -0, w: 0.6753386}
-  m_LocalPosition: {x: 139.95, y: -5.83, z: 26.2}
+  m_LocalPosition: {x: 153.29, y: -5.83, z: 26.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1810978916}
   - {fileID: 247398805}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 95.039, z: 0}
@@ -1893,7 +1808,7 @@ NavMeshAgent:
   m_AutoTraverseOffMeshLink: 1
   m_AutoBraking: 1
   m_AutoRepath: 1
-  m_Height: 5
+  m_Height: 1.8
   m_BaseOffset: -0.8
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 4
@@ -1916,10 +1831,10 @@ CapsuleCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.6668539
-  m_Height: 5.5743318
+  m_Radius: 0.30260718
+  m_Height: 1.927768
   m_Direction: 1
-  m_Center: {x: -0.08678306, y: 3.4523056, z: -0.08007103}
+  m_Center: {x: 0.017602563, y: 1.6336561, z: 0.07748512}
 --- !u!1 &2037168739
 GameObject:
   m_ObjectHideFlags: 0

--- a/Paran/ProjectSettings/TagManager.asset
+++ b/Paran/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 3
   tags:
   - Enemy
+  - InteractableObject
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
1. 좌클릭을 입력받으면 작은 형태의 collider을 플레이어 정면에 생성
2. 적이 Search 단계가 아니고 && 적의 후면에 플레이어가 위치할 때
3. collider에 enemy tag 오브젝트가 trigger되는 경우 Assasin() 호출, 호출되면 플레이어의 방향을 enemy를 바라보도록 수정
4. Assasin()에서는 특정 애니메이션 호출 후 Enemy의 상태를 Died로 변경(stateHandler.SetState(EnemySearch.EnemyState.Died))
5. died에도 조건문을 사용하여 기존에 died가 아닌 상태에서 died가 되면 애니메이션을 재생할 수 있게 함
이외
TestScene에서 collider, 감지 각도 크기 변경
TagManager 추가
저번에 그 isGrounded 기반으로 변경