### PR TITLE
Add PlayerKilled, RandomSearch, EnemyDied & modify Assasin

### DIFF
--- a/Paran/Assets/Scripting/AssasinManager.cs
+++ b/Paran/Assets/Scripting/AssasinManager.cs
@@ -37,7 +37,7 @@ public class PlayerInteract : MonoBehaviour
                 Debug.Log("Dot value: " + dot);
                 Debug.Log("Enemy State: " + stateHandler.GetState());
 
-                if (dot > 0.7f && stateHandler.GetState() != EnemySearch.EnemyState.Chase)
+                if (dot > 0.5f && stateHandler.GetState() != EnemySearch.EnemyState.Chase)
                 {
                     Debug.Log("2단계 통과");
                     Vector3 directionToEnemy = (hit.transform.position - transform.position).normalized;

--- a/Paran/Assets/Scripting/EnemyMove.cs
+++ b/Paran/Assets/Scripting/EnemyMove.cs
@@ -16,11 +16,13 @@ public class EnemyMove : MonoBehaviour
     private Vector3 lastPlayerPos;
     public float chaseDuration = 5f;     // 5초 추적
     private bool isPausingAfterChase;
+    [SerializeField] private float killRange = 5f;
 
     [Header("의심 관련")]
     private Vector3 lastKnownPlayerPos;
     public float postChasePause = 2f;    // 시야 잃으면 2초 정지
     private float pauseUntil;
+    private bool isSearching;
 
     [Header("참조 관련")]
     private NavMeshAgent agent;
@@ -30,6 +32,9 @@ public class EnemyMove : MonoBehaviour
     [Header("Look Settings")]
     public float watchTurnSpeedVision = 360f;
     public float watchTurnSpeedSound  = 120f;
+
+    [Header("기타")]
+    bool deathApplied = false;
     void Start()
     {
         agent = GetComponent<NavMeshAgent>();
@@ -81,30 +86,14 @@ public class EnemyMove : MonoBehaviour
                 break;
 
             case EnemySearch.EnemyState.Chase:
+                // 만약 시체를 봤으면 (bool) Search() 호출
                 HandleChase();
+                break;
+            case EnemySearch.EnemyState.Died:
+                if (!deathApplied) ApplyDeathOnce();
                 break;
         }
     }
-
-    /*void Patrol()
-    {
-        {
-            if (patrolPoints == null || patrolPoints.Length == 0) return;
-            if (agent.pathPending) return;
-
-            var target = patrolPoints[patrolIndex].position;
-
-            if (Vector3.Distance(transform.position, target) <= waypointTolerance)
-            {
-                patrolIndex = (patrolIndex + 1) % patrolPoints.Length;
-                target = patrolPoints[patrolIndex].position;
-                agent.SetDestination(target);
-            }
-
-            if (!agent.hasPath) agent.SetDestination(target);
-        }
-    }*/
-
     void Patrol()
     {
         if (patrolPoints == null || patrolPoints.Length == 0) return;
@@ -166,7 +155,6 @@ public class EnemyMove : MonoBehaviour
         }
         return closest;
     }
-
     void OnStateChanged(EnemySearch.EnemyState from, EnemySearch.EnemyState to)
     {
         if (to == EnemySearch.EnemyState.Chase)
@@ -215,10 +203,15 @@ public class EnemyMove : MonoBehaviour
     }
     void HandleChase()
     {
+        if (enemyManager == null || enemyManager.playerTransform == null)
+        {
+            Debug.Log("enemyManager가 올바르지 않습니다.");
+            return;
+        }
         // 추적 시간 측정 (시야가 있든 없든 5초 카운트)
         chaseTimer += Time.deltaTime;
 
-        if (enemyManager.playerVisible && enemyManager.playerTransform != null)
+        if (enemyManager.playerVisible)
         {
             // 시야를 확보하면 계속 쫓기 + 마지막 위치 갱신
             lastPlayerPos = enemyManager.playerTransform.position;
@@ -238,6 +231,17 @@ public class EnemyMove : MonoBehaviour
                 agent.isStopped = false;
                 agent.updateRotation = true;
                 agent.SetDestination(lastPlayerPos);
+            }
+        }
+        // Chase 상태에서 Player와의 사이에 장애물이 없고 
+        Vector3 flat = enemyManager.playerTransform.position - transform.position;
+        flat.y = 0f;
+        if (flat.sqrMagnitude <= killRange * killRange)
+        {
+            if (enemyManager.UpdateSharedRaycast(enemyManager.playerTransform) == EnemySearch.LosResult.Player)
+            {
+                PlayerKill();
+                return;
             }
         }
 
@@ -262,6 +266,89 @@ public class EnemyMove : MonoBehaviour
                 enemyManager.currentState = EnemySearch.EnemyState.Warning;
             }
         }
+    }
+    void Search()
+    {
+        if (isSearching || agent == null || !agent.isOnNavMesh) return;
+        StartCoroutine(CoSearch());
+    }
+
+    IEnumerator CoSearch()
+    {
+        isSearching = true;
+
+        Vector3 origin = transform.position;
+        float end = Time.time + 15f;              // 15초
+        agent.isStopped = false;
+        agent.updateRotation = true;
+
+        while (Time.time < end)
+        {
+            // 중단 조건: 사망/플레이어 발견
+            if (enemyManager == null || enemyManager.GetState() == EnemySearch.EnemyState.Died) break;
+            if (enemyManager.playerVisible && enemyManager.playerTransform != null)
+            {
+                enemyManager.currentState = EnemySearch.EnemyState.Chase;
+                agent.SetDestination(enemyManager.playerTransform.position);
+                isSearching = false; yield break;
+            }
+
+            // 반경 30m 랜덤 지점으로 이동
+            if (NavMesh.SamplePosition(origin + (Vector3)(Random.insideUnitCircle * 30f), out NavMeshHit hit, 2f, NavMesh.AllAreas))
+            {
+                agent.SetDestination(hit.position);
+
+                // 도착/중단까지 대기
+                while (Time.time < end && (agent.pathPending || agent.remainingDistance > Mathf.Max(agent.stoppingDistance, waypointTolerance)))
+                {
+                    if (enemyManager.playerVisible && enemyManager.playerTransform != null)
+                    {
+                        enemyManager.currentState = EnemySearch.EnemyState.Chase;
+                        agent.SetDestination(enemyManager.playerTransform.position);
+                        isSearching = false; yield break;
+                    }
+                    if (enemyManager.GetState() == EnemySearch.EnemyState.Died) { isSearching = false; yield break; }
+                    yield return null;
+                }
+            }
+            else yield return null;
+        }
+
+        // 수색 종료 → 경계(Warning)로 복귀 & 근처 웨이포인트 이동
+        if (enemyManager != null && enemyManager.currentState != EnemySearch.EnemyState.Chase)
+        {
+            enemyManager.currentState = EnemySearch.EnemyState.Warning;
+            if (patrolPoints != null && patrolPoints.Length > 0)
+            {
+                patrolIndex = GetClosestPatrolIndex(transform.position);
+                agent.SetDestination(patrolPoints[patrolIndex].position);
+            }
+        }
+
+        isSearching = false;
+    }
+    void PlayerKill()
+    {
+        // GameController에 요청, GamePhase 전환: RetryScene 호출
+    }
+    void ApplyDeathOnce()
+    {
+        deathApplied = true;
+
+        agent.updateRotation = false;
+        agent.isStopped = true;
+
+        int deadLayer = LayerMask.NameToLayer("DeadBody");
+        if (deadLayer == -1)
+            Debug.LogWarning("DeadBody 레이어를 먼저 Project Settings > Tags and Layers에 추가하세요.", this);
+        else
+            SetLayerRecursively(transform, deadLayer);
+    }
+
+    static void SetLayerRecursively(Transform root, int layer)
+    {
+        foreach (Transform t in root.GetComponentsInChildren<Transform>(true))
+            t.gameObject.layer = layer;
     }
     void RotateTowards(Vector3 worldPos, float degPerSec)
     {

--- a/Paran/Assets/Scripting/EnemySearch.cs
+++ b/Paran/Assets/Scripting/EnemySearch.cs
@@ -111,8 +111,7 @@ private void Update()
         }
     }
 }
-
-    private LosResult UpdateSharedRaycast(Transform target)
+    public LosResult UpdateSharedRaycast(Transform target)
     {
         if (target == null) return LosResult.None;
 
@@ -168,7 +167,7 @@ private void Update()
         if (result == LosResult.Window)
             return playerState == null || playerState.currentState != PlayerMove.PlayerState.Crawl;
         return false;
-}
+    }
 
     private bool AuditoryCheck(LosResult result)
     {
@@ -183,6 +182,12 @@ private void Update()
         // 플레이어가 'Run' 상태이고, LOS가 Player일 때만 청각 감지 + 회전
         if (result == LosResult.Player && playerState != null && playerState.currentState == PlayerMove.PlayerState.Run) return true; // 청각으로 감지됨
 
+        return false;
+    }
+    private bool DeadBodyinFov()
+    {
+        //시야각: IsPlayerinFov과 동일, 시야각 안에 layer가 DeadBody인 오브젝트가 감지되면 true 반환
+        //Wall인 물체로 가려지면 감지 불가, Window는 가능
         return false;
     }
 

--- a/Paran/Assets/Scripting/GameController.cs
+++ b/Paran/Assets/Scripting/GameController.cs
@@ -11,6 +11,7 @@ public class GameController : MonoBehaviour
         Phase3, //암살 페이즈
         Phase4, //결말 컷씬
         Phase5, //
+        Retry, // PlayerKilled, 재도전 씬
         Ending //
     }
 

--- a/Paran/Assets/순경/cop_rigged.fbx.meta
+++ b/Paran/Assets/순경/cop_rigged.fbx.meta
@@ -1,0 +1,107 @@
+fileFormatVersion: 2
+guid: bc60af7263261ba4b93da8eddfb87e8d
+ModelImporter:
+  serializedVersion: 22200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Paran/Assets/주인공/main_character_rigged.fbx.meta
+++ b/Paran/Assets/주인공/main_character_rigged.fbx.meta
@@ -1,0 +1,107 @@
+fileFormatVersion: 2
+guid: feaaf294c9b05e24382d55adaec9a99a
+ModelImporter:
+  serializedVersion: 22200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Paran/ProjectSettings/TagManager.asset
+++ b/Paran/ProjectSettings/TagManager.asset
@@ -15,7 +15,7 @@ TagManager:
   - UI
   - Wall
   - Window
-  - Deadbody
+  - DeadBody
   - Enemy
   - Ceiling
   - 


### PR DESCRIPTION
추가 로직
1. Player과 Enemy 사이에 아무 장애물이 없고 Enemy가 Chase 상태에서 거리가 5m 이하로 좁혀지면 플레이어 사망
2. Enemy 수색 로직 추가(30m 내에서 랜덤 지점 샘플링 후 이동, 이어서 샘플링 후 이동, 15초동안 지속)
3. Enemy가 죽은 경우 움직임을 멈추고 layer을 DeadBody로 변경

수정 사항
1. 암살 조금 더 판정 널널하게 조정